### PR TITLE
Bug 1199675 - Enable recovery on all sony-aosp-l devices

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -222,6 +222,10 @@ PRODUCT_PACKAGES += \
     librecovery
 
 ENABLE_LIBRECOVERY := true
+RECOVERY_EXTERNAL_STORAGE := /data/media/0
+# Enable set_metadata() and set_metadata_recursive() in updater-script
+# if device deprecates set_perm() and set_perm_recursive()
+export USE_SET_METADATA := true
 
 # Enable virtual home button for b2g
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Add RECOVERY_EXTERNAL_STORAGE path in recovery mode
Add USE_SET_METADATA for update_tools.py to build fota
package with set_metadata
