### PR TITLE
Bug 1204229 - Allow skipping download of Sony blobs if own blobs are present

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ -f ../../../vendor/qcom/proprietary/qcom-firmware.mk ]; then
+    echo "You already have the proprietary blobs. Nice!"
+    exit 0
+fi
+
 if [ -z "${DEVICE}" ]; then
     echo "You need to define the DEVICE."
     exit 1


### PR DESCRIPTION
If you are a fan of Sony devices then you may already have a
nice archive of proprietary blobs already pulled from the devices
you build for. In fact Sony's blob zip encourages this as it tries
to import vendor/qcom/proprietary/qcom-firmware.mk itself.

(see qcom/prebuilt/qcom-vendor.mk #L6 in blob zip).

Lets not punish those who already spent the time to extract blobs
from their own devices.
